### PR TITLE
Satisfied console warnings for gabz maps.

### DIFF
--- a/resources/[gabz]/cfx-gabz-247/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-247/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-altruists/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-altruists/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-ammunation/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-ammunation/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-arcade/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-arcade/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-aztecas/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-aztecas/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-bahama/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-bahama/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-ballas/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-ballas/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-barber/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-barber/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-beanmachine/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-beanmachine/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-bennys/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-bennys/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-binco/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-binco/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-bobcat/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-bobcat/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-bowling/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-bowling/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-carmeet/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-carmeet/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-davispd/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-davispd/fxmanifest.lua
@@ -13,9 +13,7 @@ dependencies {
     'cfx-gabz-pdprops', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-pdprops] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-diner/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-diner/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-esbltd/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-esbltd/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-families/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-families/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-firedept/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-firedept/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-fleeca/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-fleeca/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-harmony/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-harmony/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-haters/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-haters/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-hayes/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-hayes/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-hornys/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-hornys/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-import/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-import/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-impound/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-impound/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-lamesapd/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-lamesapd/fxmanifest.lua
@@ -13,9 +13,7 @@ dependencies {
     'cfx-gabz-pdprops', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-pdprops] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-lost/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-lost/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-lostsc/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-lostsc/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-lscustoms/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-lscustoms/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-mapdata/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-mapdata/fxmanifest.lua
@@ -28,9 +28,7 @@ client_script {
     'gabz_ipl_blockers.lua',
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'gabz-doorlocks/*.lua',

--- a/resources/[gabz]/cfx-gabz-marabunta/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-marabunta/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-mba/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-mba/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-mirrorpark1/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-mirrorpark1/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-mirrorpark2/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-mirrorpark2/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-mrpd/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-mrpd/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-ottos/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-ottos/fxmanifest.lua
@@ -14,9 +14,7 @@ dependencies {
     'cfx-gabz-pizzeria', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-pizzeria] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-pacificbank/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-pacificbank/fxmanifest.lua
@@ -13,9 +13,7 @@ dependencies {
     'cfx-gabz-pdprops', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-pdprops] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-paletobank/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-paletobank/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-paletocamp/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-paletocamp/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-paletoliquor/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-paletoliquor/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-paletopd/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-paletopd/fxmanifest.lua
@@ -13,9 +13,7 @@ dependencies {
     'cfx-gabz-pdprops', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-pdprops] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-parkranger/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-parkranger/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-pdm/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-pdm/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-pdprops/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-pdprops/fxmanifest.lua
@@ -11,9 +11,7 @@ dependencies {
     
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-pillbox/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-pillbox/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-pinkcage/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-pinkcage/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-pizzeria/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-pizzeria/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-ponsonbys/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-ponsonbys/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-prison/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-prison/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-records/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-records/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-sandypd/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-sandypd/fxmanifest.lua
@@ -13,9 +13,7 @@ dependencies {
     'cfx-gabz-pdprops', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-pdprops] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-scenarios/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-scenarios/fxmanifest.lua
@@ -17,8 +17,6 @@ files {
 
 data_file 'SCENARIO_POINTS_OVERRIDE_PSO_FILE' 'sp_manifest.ymt'
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 dependency '/assetpacks'

--- a/resources/[gabz]/cfx-gabz-studio/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-studio/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-suburban/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-suburban/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-tattoo/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-tattoo/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-townhall/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-townhall/fxmanifest.lua
@@ -13,9 +13,7 @@ dependencies {
     'cfx-gabz-pdprops', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-pdprops] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-triads/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-triads/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-tuners/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-tuners/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-vagos/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-vagos/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-vbmarket/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-vbmarket/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-vu/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-vu/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[gabz]/cfx-gabz-weedcamp/fxmanifest.lua
+++ b/resources/[gabz]/cfx-gabz-weedcamp/fxmanifest.lua
@@ -12,9 +12,7 @@ dependencies {
     'cfx-gabz-mapdata', -- ⚠️PLEASE READ⚠️; Requires [cfx-gabz-mapdata] to work properly.
 }
 
-server_scripts {
-    'version_check.lua',
-}
+
 
 escrow_ignore {
     'stream/**/*.ytd',

--- a/resources/[qb]/qb-ambulancejob/locales/en.lua
+++ b/resources/[qb]/qb-ambulancejob/locales/en.lua
@@ -39,6 +39,7 @@ local Translations = {
         healthy = 'You are completely healthy again!',
         safe = 'Hospital Safe',
         pb_hospital = 'Pillbox Hospital',
+        vc_hospital = 'Vespucci Hospital',
         pain_message = 'Your %{limb} feels %{severity}',
         many_places = 'You have pain in many places...',
         bleed_alert = 'You are %{bleedstate}',


### PR DESCRIPTION
For those people who don't want to see the console warnings of gabz version check.

`Warning: could not find server_script `version_check.lua` (defined in fxmanifest.lua:15)`

